### PR TITLE
Update string handling for file names

### DIFF
--- a/src/Fibers.cpp
+++ b/src/Fibers.cpp
@@ -1557,8 +1557,6 @@ bool Fibers::loadDmri(const QString& filename)
     return true;
 }
 
-//#include <arpa/inet.h>
-
 /********************************************//**
 \brief Method to load a TCK file
 \param filename : path of the input file to load

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -1,10 +1,6 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-#if WIN32 || _WIN32
-	#include "stdint.h"
-#endif
-
 #include <sstream>
 
 #include <QFile>


### PR DESCRIPTION
I had a crash with the x64 windows build I made on pretty much each fopen. x86 works just fine.
I found out that it actually crashed on filename.toStdString().c_str().
I replaced each of them by filename.toUtf8().constData(). Why? Because there was this one place in the code that didnt crash and used this. I didnt do more research honestly, but this definitly fixes it for me. 

Sorry for all the diffs, my VS removes extra spacing when I save. Just search for fopen to go to actual changes. 
